### PR TITLE
fix: WAL mode for concurrent access, scope dedup by target

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ async function withDb<T>(fn: (db: any) => Promise<T>): Promise<T> {
     process.exit(0);
   }
   const db = await connect(dbPath);
+  await db.exec("PRAGMA journal_mode=WAL");
   await db.exec("PRAGMA busy_timeout = 5000");
   try {
     return await fn(db);

--- a/src/store.ts
+++ b/src/store.ts
@@ -92,6 +92,7 @@ export class FeedbackStore {
       }
     }
 
+    await db.exec("PRAGMA journal_mode=WAL");
     await db.exec("PRAGMA busy_timeout = 5000");
     try {
       return await fn(db);
@@ -117,7 +118,7 @@ export class FeedbackStore {
     const now = Math.floor(Date.now() / 1000);
 
     const embedding = await this.embed(input.content);
-    const duplicate = await this.findSimilar(embedding);
+    const duplicate = await this.findSimilar(embedding, input.targetType, input.targetName);
 
     if (duplicate) {
       await this.withDb(async (db) => {
@@ -158,7 +159,7 @@ export class FeedbackStore {
     return { feedbackId: id, isDuplicate: false, votes: 1 };
   }
 
-  private async findSimilar(embedding: Float32Array): Promise<Feedback | null> {
+  private async findSimilar(embedding: Float32Array, targetType: string, targetName: string): Promise<Feedback | null> {
     return this.withDb(async (db) => {
       const vfn = this.vfn;
       const rows = await db.prepare(`
@@ -168,9 +169,10 @@ export class FeedbackStore {
                vector_distance_cos(${vfn}(embedding), ${vfn}(?)) AS distance
         FROM feedback
         WHERE embedding IS NOT NULL AND status = 'open'
+          AND target_type = ? AND target_name = ?
         ORDER BY distance ASC
         LIMIT 1
-      `).all(vecBuf(embedding)) as any[];
+      `).all(vecBuf(embedding), targetType, targetName) as any[];
 
       if (rows.length === 0) return null;
       const row = rows[0];


### PR DESCRIPTION
## Summary
- Both store.ts and cli.ts now set `PRAGMA journal_mode=WAL` when opening the DB, so the CLI doesn't choke on a lock when the MCP server's already running.
- `findSimilar` now filters by `target_type` and `target_name`, preventing feedback about unrelated tools from deduplicating against each other.

Closes #72
Closes #49

## Test plan
- [ ] Start the MCP server, then run `suggestion-box list` — should work without locking errors
- [ ] Submit similar feedback for two different targets — should create separate entries, not dedup
- [ ] Submit similar feedback for the same target — should still dedup correctly

*Submitted via [suggestion-box](https://github.com/igmagollo/suggestion-box)*