### PR TITLE
Add content validation and optional title field

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,7 @@ IMPORTANT RULES:
 
     const issueUrl = createGithubIssue(repo, {
       id: row.id,
+      title: row.title ?? null,
       content: row.content,
       category: row.category,
       targetType: row.target_type,

--- a/src/github.ts
+++ b/src/github.ts
@@ -50,9 +50,14 @@ export function createGithubIssue(
     "*Submitted via [suggestion-box](https://github.com/igmagollo/suggestion-box) — feedback registry for coding agents.*",
   ].join("\n");
 
-  // Title: first sentence or first 80 chars of content, whichever is shorter
-  const firstSentence = feedback.content.split(/[.\n]/)[0].trim();
-  const summary = firstSentence.length > 80 ? firstSentence.slice(0, 77) + "..." : firstSentence;
+  // Title: use explicit title if provided, otherwise first sentence of content
+  let summary: string;
+  if (feedback.title) {
+    summary = feedback.title;
+  } else {
+    const firstSentence = feedback.content.split(/[.\n]/)[0].trim();
+    summary = firstSentence.length > 80 ? firstSentence.slice(0, 77) + "..." : firstSentence;
+  }
   const title = `[${categoryLabel[feedback.category] ?? feedback.category}] ${summary}`;
 
   // Try to create labels (ignore failures — labels may already exist or user may lack permissions)

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -61,12 +61,13 @@ Use category "observation" when:
 
 If similar feedback already exists, your submission becomes a vote on it instead of creating a duplicate. Include impact estimates to help prioritize.`,
     submitFeedbackSchema.shape,
-    async ({ category, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes }) => {
+    async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes }) => {
       try {
         store.embedPending().catch((e) => console.error("[suggestion-box] embedPending error:", e));
 
         const result = await store.submitFeedback({
           category,
+          title,
           content,
           targetType: target_type,
           targetName: target_name,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 
 export const submitFeedbackSchema = z.object({
   category: z.enum(["friction", "feature_request", "observation"]).describe("Type of feedback"),
-  content: z.string().describe("Detailed description of the feedback"),
+  title: z.string().max(100, "Title must be 100 characters or fewer").optional().describe("Short summary for the feedback (used as GitHub issue title when published)"),
+  content: z.string().min(20, "Feedback must be at least 20 characters — provide enough detail to be actionable").max(5000, "Feedback must be 5000 characters or fewer").describe("Detailed description of the feedback"),
   target_type: z.enum(["mcp_server", "tool", "codebase", "workflow", "general"]).describe("What kind of thing this feedback is about"),
   target_name: z.string().describe("Name of the target (e.g., 'context7', 'gh CLI', 'src/auth')"),
   github_repo: z.string().optional().describe("GitHub repo for publishing (e.g., 'owner/repo')"),

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,7 @@ function vecBuf(vec: Float32Array): Buffer {
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS feedback (
     id                          TEXT PRIMARY KEY,
+    title                       TEXT,
     content                     TEXT NOT NULL,
     embedding                   BLOB,
     category                    TEXT NOT NULL,
@@ -104,6 +105,12 @@ export class FeedbackStore {
     if (this.initialized) return;
     await this.withDb(async (db) => {
       await db.exec(SCHEMA);
+      // Migrate existing databases: add title column if missing
+      try {
+        await db.exec("ALTER TABLE feedback ADD COLUMN title TEXT");
+      } catch {
+        // Column already exists — ignore
+      }
     });
     this.initialized = true;
   }
@@ -141,10 +148,10 @@ export class FeedbackStore {
     const id = randomUUID();
     await this.withDb(async (db) => {
       await db.prepare(
-        `INSERT INTO feedback (id, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?)`
+        `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?)`
       ).run(
-        id, input.content, vecBuf(embedding), input.category, input.targetType,
+        id, input.title ?? null, input.content, vecBuf(embedding), input.category, input.targetType,
         input.targetName, input.githubRepo ?? null,
         input.estimatedTokensSaved ?? null, input.estimatedTimeSavedMinutes ?? null,
         now, now, this.sessionId
@@ -162,7 +169,7 @@ export class FeedbackStore {
     return this.withDb(async (db) => {
       const vfn = this.vfn;
       const rows = await db.prepare(`
-        SELECT id, content, category, target_type, target_name, github_repo,
+        SELECT id, title, content, category, target_type, target_name, github_repo,
                status, votes, estimated_tokens_saved, estimated_time_saved_minutes,
                created_at, updated_at, published_issue_url, session_id,
                vector_distance_cos(${vfn}(embedding), ${vfn}(?)) AS distance
@@ -184,6 +191,7 @@ export class FeedbackStore {
   private rowToFeedback(row: any): Feedback {
     return {
       id: row.id,
+      title: row.title ?? null,
       content: row.content,
       category: row.category,
       targetType: row.target_type,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface SupervisorConfig {
 
 export interface Feedback {
   id: string;
+  title: string | null;
   content: string;
   category: FeedbackCategory;
   targetType: TargetType;
@@ -44,6 +45,7 @@ export interface Feedback {
 
 export interface SubmitFeedbackInput {
   category: FeedbackCategory;
+  title?: string;
   content: string;
   targetType: TargetType;
   targetName: string;


### PR DESCRIPTION
## Summary
- Content field now enforces min 20 / max 5000 characters so agents can't submit empty or absurdly large feedback
- New optional `title` field (max 100 chars) on the submit schema, stored in the DB, and used as the GitHub issue title when publishing
- When no title is provided, falls back to first sentence of content (existing behavior)
- Existing databases get the new column via an `ALTER TABLE` migration on init

Closes #61
Closes #73

## Test plan
- [ ] Submit feedback with content under 20 chars and verify schema rejects it
- [ ] Submit feedback with content over 5000 chars and verify schema rejects it
- [ ] Submit feedback with a title and verify it shows up in the published GitHub issue
- [ ] Submit feedback without a title and verify fallback to first sentence still works
- [ ] Run against an existing DB and confirm the title column gets added without errors

*Submitted via [suggestion-box](https://github.com/igmagollo/suggestion-box)*