### PR TITLE
perf: use persistent DB connection for MCP server

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -30,6 +30,7 @@ export async function startMcpServer(): Promise<void> {
     dbPath,
     sessionId: randomUUID(),
     embed,
+    persistent: true,
   });
 
   await store.init();
@@ -271,8 +272,10 @@ If similar feedback already exists, your submission becomes a vote on it instead
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  process.on("SIGINT", () => {
+  const shutdown = () => {
     store.close();
     process.exit(0);
-  });
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -63,6 +63,8 @@ export class FeedbackStore {
   private readonly embed: SupervisorConfig["embed"];
   private readonly vectorType: string;
   private readonly dedupThreshold: number;
+  private readonly persistent: boolean;
+  private cachedDb: Database | null = null;
 
   constructor(config: SupervisorConfig) {
     this.dbPath = config.dbPath;
@@ -70,9 +72,13 @@ export class FeedbackStore {
     this.embed = config.embed;
     this.vectorType = config.vectorType ?? "vector32";
     this.dedupThreshold = config.dedupThreshold ?? 0.85;
+    this.persistent = config.persistent ?? false;
   }
 
-  private async withDb<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+  /**
+   * Open a new DB connection with retry logic for lock contention.
+   */
+  private async openConnection(): Promise<Database> {
     const maxRetries = 10;
     const baseDelay = 50;
 
@@ -95,6 +101,31 @@ export class FeedbackStore {
 
     await db.exec("PRAGMA journal_mode=WAL");
     await db.exec("PRAGMA busy_timeout = 5000");
+    return db;
+  }
+
+  /**
+   * Get the persistent DB connection, creating it if needed.
+   */
+  private async getDb(): Promise<Database> {
+    if (!this.cachedDb) {
+      this.cachedDb = await this.openConnection();
+    }
+    return this.cachedDb;
+  }
+
+  /**
+   * Execute a function with a DB connection.
+   * In persistent mode, reuses a single long-lived connection.
+   * In non-persistent mode (CLI), opens and closes per operation.
+   */
+  private async withDb<T>(fn: (db: Database) => Promise<T>): Promise<T> {
+    if (this.persistent) {
+      const db = await this.getDb();
+      return fn(db);
+    }
+
+    const db = await this.openConnection();
     try {
       return await fn(db);
     } finally {
@@ -388,6 +419,10 @@ export class FeedbackStore {
   }
 
   async close(): Promise<void> {
+    if (this.cachedDb) {
+      this.cachedDb.close();
+      this.cachedDb = null;
+    }
     this.initialized = false;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface SupervisorConfig {
   vectorType?: VectorType;
   /** Cosine similarity threshold for dedup (default: 0.85) */
   dedupThreshold?: number;
+  /** Use a persistent DB connection instead of open/close per operation (default: false) */
+  persistent?: boolean;
 }
 
 export interface Feedback {


### PR DESCRIPTION
## Summary
- Adds a `persistent` option to `SupervisorConfig` that keeps a single long-lived DB connection instead of opening/closing per operation
- MCP server (`src/mcp.ts`) now uses `persistent: true` — one connection for its entire lifetime with WAL mode
- CLI continues using the existing open/close-per-operation pattern (default `persistent: false`)
- Persistent connection is properly closed on SIGINT and SIGTERM

## Test plan
- [ ] Start MCP server, submit multiple feedback items, verify they work without reconnection overhead
- [ ] Run CLI commands (list, status, publish), verify they still work with per-operation connections
- [ ] Kill MCP server with SIGINT/SIGTERM, verify clean shutdown (no locked DB)
- [ ] Run `npx tsc --noEmit` — passes clean

Closes #68