### PR TITLE
feat: lightweight trigram fallback for dedup (drop HuggingFace requirement)

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -2,23 +2,83 @@ import type { EmbedFn } from "./types.js";
 
 let cachedEmbedder: EmbedFn | null = null;
 
+/**
+ * Symbol used to tag an EmbedFn that operates in trigram-fallback mode.
+ * When present, the store should use trigram Jaccard similarity instead of
+ * vector cosine distance for dedup.
+ */
+export const TRIGRAM_MODE = Symbol.for("suggestion-box:trigram-mode");
+
+/** Compute the set of character trigrams for a given string. */
+export function trigrams(text: string): Set<string> {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  const result = new Set<string>();
+  for (let i = 0; i <= normalized.length - 3; i++) {
+    result.add(normalized.slice(i, i + 3));
+  }
+  return result;
+}
+
+/** Jaccard similarity between two trigram sets: |intersection| / |union|. */
+export function trigramSimilarity(a: string, b: string): number {
+  const setA = trigrams(a);
+  const setB = trigrams(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+
+  let intersection = 0;
+  for (const t of setA) {
+    if (setB.has(t)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Default trigram Jaccard threshold for dedup (empirically ~0.35 is a good match). */
+export const DEFAULT_TRIGRAM_THRESHOLD = 0.35;
+
+/** Check whether an embed function is in trigram-fallback mode. */
+export function isTrigramMode(embed: EmbedFn): boolean {
+  return (embed as any)[TRIGRAM_MODE] === true;
+}
+
 export async function createEmbedder(opts?: {
   model?: string;
   quantized?: boolean;
 }): Promise<EmbedFn> {
   if (cachedEmbedder) return cachedEmbedder;
 
-  const { pipeline } = await import("@huggingface/transformers");
+  // Allow users to explicitly disable HuggingFace embeddings
+  const envFlag = process.env.SUGGESTION_BOX_EMBEDDINGS;
+  const embeddingsDisabled = envFlag !== undefined && envFlag.toLowerCase() === "false";
 
-  const model = opts?.model ?? process.env.SUGGESTION_BOX_MODEL ?? "Xenova/all-MiniLM-L6-v2";
-  const quantized = opts?.quantized ?? true;
+  if (!embeddingsDisabled) {
+    try {
+      const { pipeline } = await import("@huggingface/transformers");
 
-  const extractor = await pipeline("feature-extraction", model, { quantized } as any);
+      const model = opts?.model ?? process.env.SUGGESTION_BOX_MODEL ?? "Xenova/all-MiniLM-L6-v2";
+      const quantized = opts?.quantized ?? true;
 
-  cachedEmbedder = async (text: string): Promise<Float32Array> => {
-    const output = await extractor(text, { pooling: "mean", normalize: true });
-    return new Float32Array(output.data as Float64Array);
+      const extractor = await pipeline("feature-extraction", model, { quantized } as any);
+
+      cachedEmbedder = async (text: string): Promise<Float32Array> => {
+        const output = await extractor(text, { pooling: "mean", normalize: true });
+        return new Float32Array(output.data as Float64Array);
+      };
+
+      return cachedEmbedder;
+    } catch {
+      // HuggingFace model failed to load — fall back to trigram mode
+    }
+  }
+
+  // Trigram fallback: return a tagged no-op embed function.
+  // The store detects this tag and uses trigram similarity instead of vector distance.
+  const trigramEmbed: EmbedFn = async (_text: string): Promise<Float32Array> => {
+    return new Float32Array(0);
   };
+  (trigramEmbed as any)[TRIGRAM_MODE] = true;
 
+  cachedEmbedder = trigramEmbed;
   return cachedEmbedder;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { connect } from "@tursodatabase/database";
 import { randomUUID } from "crypto";
+import { isTrigramMode, trigramSimilarity, DEFAULT_TRIGRAM_THRESHOLD } from "./embedder.js";
 import type {
   SupervisorConfig,
   Feedback,
@@ -65,6 +66,8 @@ export class FeedbackStore {
   private readonly dedupThreshold: number;
   private readonly persistent: boolean;
   private cachedDb: Database | null = null;
+  private readonly useTrigramDedup: boolean;
+  private readonly trigramThreshold: number;
 
   constructor(config: SupervisorConfig) {
     this.dbPath = config.dbPath;
@@ -73,6 +76,8 @@ export class FeedbackStore {
     this.vectorType = config.vectorType ?? "vector32";
     this.dedupThreshold = config.dedupThreshold ?? 0.85;
     this.persistent = config.persistent ?? false;
+    this.useTrigramDedup = isTrigramMode(config.embed);
+    this.trigramThreshold = DEFAULT_TRIGRAM_THRESHOLD;
   }
 
   /**
@@ -155,8 +160,9 @@ export class FeedbackStore {
     await this.init();
     const now = Math.floor(Date.now() / 1000);
 
-    const embedding = await this.embed(input.content);
-    const duplicate = await this.findSimilar(embedding, input.targetType, input.targetName);
+    const duplicate = this.useTrigramDedup
+      ? await this.findSimilarByTrigram(input.content, input.targetType, input.targetName)
+      : await this.findSimilarByEmbedding(input.content, input.targetType, input.targetName);
 
     if (duplicate) {
       await this.withDb(async (db) => {
@@ -178,12 +184,14 @@ export class FeedbackStore {
     }
 
     const id = randomUUID();
+    const embedding = this.useTrigramDedup ? null : await this.embed(input.content);
+
     await this.withDb(async (db) => {
       await db.prepare(
         `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?)`
       ).run(
-        id, input.title ?? null, input.content, vecBuf(embedding), input.category, input.targetType,
+        id, input.title ?? null, input.content, embedding ? vecBuf(embedding) : null, input.category, input.targetType,
         input.targetName, input.githubRepo ?? null,
         input.estimatedTokensSaved ?? null, input.estimatedTimeSavedMinutes ?? null,
         now, now, this.sessionId
@@ -197,7 +205,9 @@ export class FeedbackStore {
     return { feedbackId: id, isDuplicate: false, votes: 1 };
   }
 
-  private async findSimilar(embedding: Float32Array, targetType: string, targetName: string): Promise<Feedback | null> {
+  /** Find similar feedback using cosine distance on embeddings (HuggingFace mode). */
+  private async findSimilarByEmbedding(content: string, targetType: string, targetName: string): Promise<Feedback | null> {
+    const embedding = await this.embed(content);
     return this.withDb(async (db) => {
       const vfn = this.vfn;
       const rows = await db.prepare(`
@@ -218,6 +228,37 @@ export class FeedbackStore {
       if (similarity < this.dedupThreshold) return null;
 
       return this.rowToFeedback(row);
+    });
+  }
+
+  /** Find similar feedback using trigram Jaccard similarity (lightweight fallback). */
+  private async findSimilarByTrigram(content: string, targetType: string, targetName: string): Promise<Feedback | null> {
+    return this.withDb(async (db) => {
+      const rows = await db.prepare(`
+        SELECT id, title, content, category, target_type, target_name, github_repo,
+               status, votes, estimated_tokens_saved, estimated_time_saved_minutes,
+               created_at, updated_at, published_issue_url, session_id
+        FROM feedback
+        WHERE status = 'open'
+          AND target_type = ? AND target_name = ?
+      `).all(targetType, targetName) as any[];
+
+      if (rows.length === 0) return null;
+
+      let bestRow: any = null;
+      let bestSimilarity = 0;
+
+      for (const row of rows) {
+        const sim = trigramSimilarity(content, row.content);
+        if (sim > bestSimilarity) {
+          bestSimilarity = sim;
+          bestRow = row;
+        }
+      }
+
+      if (!bestRow || bestSimilarity < this.trigramThreshold) return null;
+
+      return this.rowToFeedback(bestRow);
     });
   }
 
@@ -386,6 +427,9 @@ export class FeedbackStore {
   }
 
   async embedPending(): Promise<number> {
+    // In trigram mode, embeddings are not used — nothing to backfill
+    if (this.useTrigramDedup) return 0;
+
     await this.init();
     const rows = await this.withDb(async (db) => {
       return await db.prepare(


### PR DESCRIPTION
## Summary

- Adds trigram-based Jaccard similarity as a lightweight dedup fallback in `src/embedder.ts`, eliminating the need for the ~100MB `@huggingface/transformers` dependency and model download
- HuggingFace embeddings remain the default but gracefully fall back to trigrams when `SUGGESTION_BOX_EMBEDDINGS=false` is set or the model fails to load
- `src/store.ts` routes dedup through either vector cosine distance (embedding mode) or trigram Jaccard comparison (fallback mode), with a 0.35 threshold for trigrams vs 0.85 for cosine
- In trigram mode, `embedPending()` is a no-op and no embeddings are stored, keeping the DB lean

Closes #58

## Test plan

- [ ] Verify `npx tsc --noEmit` passes
- [ ] Start MCP server normally (HuggingFace loads) and confirm dedup still works via cosine similarity
- [ ] Set `SUGGESTION_BOX_EMBEDDINGS=false` and start MCP server — confirm it starts without downloading any model
- [ ] Submit two similar feedback items in trigram mode and verify dedup detects the duplicate
- [ ] Submit two distinct feedback items in trigram mode and verify both are stored separately