### PR TITLE
Validate config on MCP server startup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,135 @@
+import { resolve, dirname } from "path";
+import { existsSync, mkdirSync, accessSync, constants, statSync } from "fs";
+
+export interface ConfigValidationResult {
+  valid: boolean;
+  dataDir: string;
+  dbPath: string;
+  errors: string[];
+}
+
+/**
+ * Validate the suggestion-box configuration and environment before starting.
+ * Returns structured results with actionable error messages.
+ */
+export function validateConfig(): ConfigValidationResult {
+  const errors: string[] = [];
+
+  const rawDir = process.env.SUGGESTION_BOX_DIR ?? ".suggestion-box";
+  const dataDir = resolve(rawDir);
+  const dbPath = resolve(dataDir, "feedback.db");
+
+  // Check if the data directory exists
+  if (existsSync(dataDir)) {
+    // Verify it's actually a directory, not a file
+    try {
+      const stat = statSync(dataDir);
+      if (!stat.isDirectory()) {
+        errors.push(
+          `SUGGESTION_BOX_DIR points to "${dataDir}" which exists but is not a directory. ` +
+          `Remove the file or set SUGGESTION_BOX_DIR to a different path.`
+        );
+      }
+    } catch (e: any) {
+      errors.push(
+        `Cannot stat "${dataDir}": ${e.message}`
+      );
+    }
+
+    // Verify the directory is writable (needed for DB operations)
+    if (errors.length === 0) {
+      try {
+        accessSync(dataDir, constants.W_OK);
+      } catch {
+        errors.push(
+          `Data directory "${dataDir}" is not writable. ` +
+          `Check permissions or set SUGGESTION_BOX_DIR to a writable path.`
+        );
+      }
+    }
+  } else {
+    // Directory doesn't exist — check if we can create it
+    const parent = dirname(dataDir);
+    if (!existsSync(parent)) {
+      errors.push(
+        `Cannot create data directory "${dataDir}": parent directory "${parent}" does not exist. ` +
+        `Create it first or set SUGGESTION_BOX_DIR to a valid path. ` +
+        `Run 'suggestion-box init' to set up the project.`
+      );
+    } else {
+      try {
+        accessSync(parent, constants.W_OK);
+      } catch {
+        errors.push(
+          `Cannot create data directory "${dataDir}": parent "${parent}" is not writable. ` +
+          `Check permissions or set SUGGESTION_BOX_DIR to a writable path.`
+        );
+      }
+
+      // Try to actually create it
+      if (errors.length === 0) {
+        try {
+          mkdirSync(dataDir, { recursive: true });
+        } catch (e: any) {
+          errors.push(
+            `Failed to create data directory "${dataDir}": ${e.message}`
+          );
+        }
+      }
+    }
+  }
+
+  // If the DB file already exists, check it's writable
+  if (errors.length === 0 && existsSync(dbPath)) {
+    try {
+      accessSync(dbPath, constants.R_OK | constants.W_OK);
+    } catch {
+      errors.push(
+        `Database file "${dbPath}" is not readable/writable. ` +
+        `Check file permissions.`
+      );
+    }
+
+    // Also check for WAL/SHM companion files
+    const walPath = dbPath + "-wal";
+    const shmPath = dbPath + "-shm";
+    for (const companion of [walPath, shmPath]) {
+      if (existsSync(companion)) {
+        try {
+          accessSync(companion, constants.R_OK | constants.W_OK);
+        } catch {
+          errors.push(
+            `Database companion file "${companion}" is not readable/writable. ` +
+            `Check file permissions or delete stale WAL/SHM files.`
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    dataDir,
+    dbPath,
+    errors,
+  };
+}
+
+/**
+ * Validate config and throw with a clear message if anything is wrong.
+ * Used by the MCP server on startup.
+ */
+export function assertValidConfig(): { dataDir: string; dbPath: string } {
+  const result = validateConfig();
+  if (!result.valid) {
+    const msg = [
+      "suggestion-box: configuration error",
+      "",
+      ...result.errors.map((e, i) => `  ${i + 1}. ${e}`),
+      "",
+      "Tip: Run 'suggestion-box init' to set up the project, or check your SUGGESTION_BOX_DIR environment variable.",
+    ].join("\n");
+    throw new Error(msg);
+  }
+  return { dataDir: result.dataDir, dbPath: result.dbPath };
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,8 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createFeedbackStore } from "./sdk.js";
 import { createEmbedder } from "./embedder.js";
-import { resolve } from "path";
-import { existsSync, mkdirSync } from "fs";
 import { randomUUID } from "crypto";
 import {
   submitFeedbackSchema,
@@ -13,16 +11,10 @@ import {
   publishToGithubSchema,
 } from "./schemas.js";
 import { checkGhAuth, createGithubIssue } from "./github.js";
-
-function getDataDir(): string {
-  const dir = resolve(process.env.SUGGESTION_BOX_DIR ?? ".suggestion-box");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  return dir;
-}
+import { assertValidConfig } from "./config.js";
 
 export async function startMcpServer(): Promise<void> {
-  const dataDir = getDataDir();
-  const dbPath = resolve(dataDir, "feedback.db");
+  const { dataDir, dbPath } = assertValidConfig();
 
   const embed = await createEmbedder();
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { validateConfig, assertValidConfig } from "../src/config.js";
+import { mkdtemp, rm, writeFile, chmod } from "fs/promises";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "sb-config-test-"));
+});
+
+afterEach(async () => {
+  // Restore env
+  delete process.env.SUGGESTION_BOX_DIR;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("validateConfig", () => {
+  test("valid when data dir exists and is writable", () => {
+    const dataDir = join(tmpDir, ".suggestion-box");
+    mkdirSync(dataDir);
+    process.env.SUGGESTION_BOX_DIR = dataDir;
+
+    const result = validateConfig();
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.dataDir).toBe(dataDir);
+    expect(result.dbPath).toBe(join(dataDir, "feedback.db"));
+  });
+
+  test("valid when data dir does not exist but parent is writable", () => {
+    const dataDir = join(tmpDir, "new-data-dir");
+    process.env.SUGGESTION_BOX_DIR = dataDir;
+
+    const result = validateConfig();
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("error when data dir path is a file, not a directory", async () => {
+    const filePath = join(tmpDir, "not-a-dir");
+    await writeFile(filePath, "oops");
+    process.env.SUGGESTION_BOX_DIR = filePath;
+
+    const result = validateConfig();
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(1);
+    expect(result.errors[0]).toContain("not a directory");
+  });
+
+  test("error when parent directory does not exist", () => {
+    process.env.SUGGESTION_BOX_DIR = "/tmp/nonexistent-parent-abc123/data";
+
+    const result = validateConfig();
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("parent directory");
+    expect(result.errors[0]).toContain("does not exist");
+  });
+
+  test("checks DB file permissions when DB exists", async () => {
+    const dataDir = join(tmpDir, ".suggestion-box");
+    mkdirSync(dataDir);
+    const dbPath = join(dataDir, "feedback.db");
+    writeFileSync(dbPath, "");
+    process.env.SUGGESTION_BOX_DIR = dataDir;
+
+    // DB file exists and is readable/writable — should be valid
+    const result = validateConfig();
+    expect(result.valid).toBe(true);
+  });
+
+  test("checks WAL companion file permissions", async () => {
+    const dataDir = join(tmpDir, ".suggestion-box");
+    mkdirSync(dataDir);
+    const dbPath = join(dataDir, "feedback.db");
+    writeFileSync(dbPath, "");
+    writeFileSync(dbPath + "-wal", "");
+    process.env.SUGGESTION_BOX_DIR = dataDir;
+
+    // Both exist and are writable — should be valid
+    const result = validateConfig();
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("assertValidConfig", () => {
+  test("returns dataDir and dbPath on valid config", () => {
+    const dataDir = join(tmpDir, ".suggestion-box");
+    mkdirSync(dataDir);
+    process.env.SUGGESTION_BOX_DIR = dataDir;
+
+    const result = assertValidConfig();
+    expect(result.dataDir).toBe(dataDir);
+    expect(result.dbPath).toBe(join(dataDir, "feedback.db"));
+  });
+
+  test("throws with actionable message on invalid config", () => {
+    process.env.SUGGESTION_BOX_DIR = "/tmp/nonexistent-parent-abc123/data";
+
+    expect(() => assertValidConfig()).toThrow("configuration error");
+  });
+
+  test("error message includes init hint", () => {
+    process.env.SUGGESTION_BOX_DIR = "/tmp/nonexistent-parent-abc123/data";
+
+    try {
+      assertValidConfig();
+      expect(true).toBe(false); // should not reach
+    } catch (e: any) {
+      expect(e.message).toContain("suggestion-box init");
+    }
+  });
+});


### PR DESCRIPTION
Closes #110

When the MCP server starts, it now validates the environment before doing anything else — data directory exists (or can be created), permissions are correct, DB file is writable, WAL companion files aren't locked out. If something's off, you get a numbered list of what's wrong and what to do about it, instead of a stack trace from deep inside libSQL.

The old `getDataDir()` helper in mcp.ts is replaced by `assertValidConfig()` from a new `src/config.ts` module. The validation covers: directory-vs-file conflicts, missing parent directories, write permissions on the data dir, DB file, and WAL/SHM files. Each error message tells you exactly what to fix.

Tests cover the happy path and all the failure modes (file where dir should be, missing parent, permission checks on DB and WAL files).