### PR TITLE
Add content quality filter for feedback submissions

### DIFF
--- a/src/quality.ts
+++ b/src/quality.ts
@@ -1,0 +1,81 @@
+/**
+ * Quality filter for feedback submissions.
+ *
+ * Rejects vague, spammy, or low-effort content that would clutter the queue.
+ * Runs after basic length validation (min 20, max 5000 chars from zod schema).
+ */
+
+export interface QualityIssue {
+  code: string;
+  message: string;
+}
+
+const MIN_WORD_COUNT = 5;
+const MAX_CAPS_RATIO = 0.7;
+const MIN_UNIQUE_WORDS = 3;
+
+/**
+ * Words that are too vague on their own to constitute useful feedback.
+ * We check whether the *entire* content (after trimming) is just filler.
+ */
+const FILLER_PATTERNS: RegExp[] = [
+  /^(this is (bad|good|broken|wrong|fine|ok|okay|great|terrible|awful)\.?)$/i,
+  /^(it (doesn'?t|does not) work\.?)$/i,
+  /^(please fix\.?|fix (this|it)\.?|needs? fix(ing)?\.?)$/i,
+  /^(something is (wrong|broken|off)\.?)$/i,
+  /^(not working\.?|doesn'?t work\.?|broken\.?)$/i,
+  /^(i (don'?t |do not )?(like|want) (this|it)\.?)$/i,
+  /^(change (this|it)\.?|update (this|it)\.?)$/i,
+  /^(todo:?\.?|fixme:?\.?|hack:?\.?)$/i,
+];
+
+/**
+ * Validate the quality of feedback content.
+ * Returns an empty array if the content passes all checks.
+ */
+export function validateContentQuality(content: string): QualityIssue[] {
+  const issues: QualityIssue[] = [];
+  const trimmed = content.trim();
+
+  // --- Word count check ---
+  const words = trimmed.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length < MIN_WORD_COUNT) {
+    issues.push({
+      code: "too_few_words",
+      message: `Feedback must contain at least ${MIN_WORD_COUNT} words — provide enough detail to be actionable (got ${words.length}).`,
+    });
+  }
+
+  // --- All-caps spam check ---
+  const letters = trimmed.replace(/[^a-zA-Z]/g, "");
+  if (letters.length > 0) {
+    const upperCount = letters.replace(/[^A-Z]/g, "").length;
+    const capsRatio = upperCount / letters.length;
+    if (capsRatio > MAX_CAPS_RATIO && letters.length >= 10) {
+      issues.push({
+        code: "excessive_caps",
+        message: `Feedback looks like all-caps spam (${Math.round(capsRatio * 100)}% uppercase). Please write normally.`,
+      });
+    }
+  }
+
+  // --- Unique word diversity check ---
+  const normalized = words.map((w) => w.toLowerCase().replace(/[^a-z0-9]/g, "")).filter((w) => w.length > 0);
+  const unique = new Set(normalized);
+  if (normalized.length >= MIN_WORD_COUNT && unique.size < MIN_UNIQUE_WORDS) {
+    issues.push({
+      code: "low_diversity",
+      message: `Feedback is too repetitive — use at least ${MIN_UNIQUE_WORDS} distinct words to describe the issue.`,
+    });
+  }
+
+  // --- Filler / vague content check ---
+  if (FILLER_PATTERNS.some((p) => p.test(trimmed))) {
+    issues.push({
+      code: "vague_content",
+      message: "Feedback is too vague to be actionable. Describe what happened, what you expected, and why it matters.",
+    });
+  }
+
+  return issues;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,9 +1,19 @@
 import { z } from "zod";
+import { validateContentQuality } from "./quality.js";
 
 export const submitFeedbackSchema = z.object({
   category: z.enum(["friction", "feature_request", "observation"]).describe("Type of feedback"),
   title: z.string().max(100, "Title must be 100 characters or fewer").optional().describe("Short summary for the feedback (used as GitHub issue title when published)"),
-  content: z.string().min(20, "Feedback must be at least 20 characters — provide enough detail to be actionable").max(5000, "Feedback must be 5000 characters or fewer").describe("Detailed description of the feedback"),
+  content: z.string().min(20, "Feedback must be at least 20 characters — provide enough detail to be actionable").max(5000, "Feedback must be 5000 characters or fewer").superRefine((val, ctx) => {
+    const issues = validateContentQuality(val);
+    for (const issue of issues) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: issue.message,
+        params: { qualityCode: issue.code },
+      });
+    }
+  }).describe("Detailed description of the feedback"),
   target_type: z.enum(["mcp_server", "tool", "codebase", "workflow", "general"]).describe("What kind of thing this feedback is about"),
   target_name: z.string().describe("Name of the target (e.g., 'context7', 'gh CLI', 'src/auth')"),
   github_repo: z.string().optional().describe("GitHub repo for publishing (e.g., 'owner/repo')"),

--- a/tests/quality.test.ts
+++ b/tests/quality.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from "bun:test";
+import { validateContentQuality } from "../src/quality.js";
+import { submitFeedbackSchema } from "../src/schemas.js";
+
+describe("validateContentQuality", () => {
+  describe("word count", () => {
+    test("rejects content with fewer than 5 words", () => {
+      const issues = validateContentQuality("needs more detail here");
+      expect(issues.some((i) => i.code === "too_few_words")).toBe(true);
+    });
+
+    test("accepts content with 5 or more words", () => {
+      const issues = validateContentQuality("this has exactly five words here");
+      expect(issues.some((i) => i.code === "too_few_words")).toBe(false);
+    });
+
+    test("rejects a single long word padded to 20 chars", () => {
+      // "aaaaaaaaaaaaaaaaaaaa" is 20 chars but only 1 word
+      const issues = validateContentQuality("aaaaaaaaaaaaaaaaaaaa");
+      expect(issues.some((i) => i.code === "too_few_words")).toBe(true);
+    });
+  });
+
+  describe("all-caps detection", () => {
+    test("rejects mostly uppercase content", () => {
+      const issues = validateContentQuality("THIS TOOL IS COMPLETELY BROKEN AND NEEDS FIXING NOW");
+      expect(issues.some((i) => i.code === "excessive_caps")).toBe(true);
+    });
+
+    test("accepts normal mixed-case content", () => {
+      const issues = validateContentQuality("The search tool returns stale results when querying recent files");
+      expect(issues.some((i) => i.code === "excessive_caps")).toBe(false);
+    });
+
+    test("allows short uppercase abbreviations in otherwise normal text", () => {
+      const issues = validateContentQuality("The MCP server's API endpoint returns HTTP 500 errors intermittently");
+      expect(issues.some((i) => i.code === "excessive_caps")).toBe(false);
+    });
+
+    test("ignores caps ratio for very short letter content", () => {
+      // Under 10 letters, we don't flag caps
+      const issues = validateContentQuality("OK IT 12345 67890 extra");
+      expect(issues.some((i) => i.code === "excessive_caps")).toBe(false);
+    });
+  });
+
+  describe("word diversity", () => {
+    test("rejects highly repetitive content", () => {
+      const issues = validateContentQuality("bad bad bad bad bad bad bad");
+      expect(issues.some((i) => i.code === "low_diversity")).toBe(true);
+    });
+
+    test("accepts content with diverse vocabulary", () => {
+      const issues = validateContentQuality("the search tool returns incorrect results for recent queries");
+      expect(issues.some((i) => i.code === "low_diversity")).toBe(false);
+    });
+  });
+
+  describe("filler / vague content", () => {
+    test.each([
+      "it doesn't work",
+      "It doesn't work.",
+      "it does not work",
+      "please fix",
+      "Please fix.",
+      "fix this",
+      "not working",
+      "broken",
+      "this is broken",
+      "something is wrong",
+      "needs fixing",
+    ])("rejects vague content: %s", (content) => {
+      const issues = validateContentQuality(content);
+      expect(issues.some((i) => i.code === "vague_content")).toBe(true);
+    });
+
+    test("accepts detailed content that happens to contain filler phrases", () => {
+      const issues = validateContentQuality(
+        "The search results endpoint doesn't work when the query contains special characters like parentheses"
+      );
+      expect(issues.some((i) => i.code === "vague_content")).toBe(false);
+    });
+  });
+
+  describe("good feedback passes all checks", () => {
+    test.each([
+      "The context7 MCP server times out after 30 seconds when querying large repositories with more than 1000 files",
+      "Feature request: add a --json flag to the list command so output can be piped to jq for filtering",
+      "The embedder falls back to trigram mode silently — it would help to log a warning when HuggingFace is unavailable",
+      "When running suggestion-box init in a monorepo, the relative path in mcp.json points to the wrong directory",
+    ])("accepts: %s", (content) => {
+      const issues = validateContentQuality(content);
+      expect(issues).toHaveLength(0);
+    });
+  });
+});
+
+describe("schema integration", () => {
+  const base = {
+    category: "friction" as const,
+    target_type: "mcp_server" as const,
+    target_name: "suggestion-box",
+  };
+
+  test("rejects low-quality content through the schema", () => {
+    const result = submitFeedbackSchema.safeParse({
+      ...base,
+      content: "bad bad bad bad bad bad bad",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes("repetitive"))).toBe(true);
+    }
+  });
+
+  test("accepts good quality content through the schema", () => {
+    const result = submitFeedbackSchema.safeParse({
+      ...base,
+      content: "The search tool returns stale cached results when files have been modified within the last 5 seconds",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("quality checks run after length checks", () => {
+    // Too short should fail on length, not quality
+    const result = submitFeedbackSchema.safeParse({
+      ...base,
+      content: "short",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("at least 20 characters");
+    }
+  });
+});

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -56,10 +56,10 @@ describe("submitFeedbackSchema", () => {
       expect(result.success).toBe(false);
     });
 
-    test("accepts content exactly 20 characters", () => {
+    test("accepts content near minimum length with enough quality", () => {
       const result = submitFeedbackSchema.safeParse({
         ...validInput,
-        content: "a".repeat(20),
+        content: "The search tool breaks on special chars",
       });
       expect(result.success).toBe(true);
     });
@@ -72,10 +72,13 @@ describe("submitFeedbackSchema", () => {
       expect(result.success).toBe(false);
     });
 
-    test("accepts content exactly 5000 characters", () => {
+    test("accepts content near max length with enough quality", () => {
+      // Build a long but realistic content string
+      const sentence = "The search tool returns incorrect results for queries with special characters. ";
+      const content = sentence.repeat(Math.floor(4999 / sentence.length));
       const result = submitFeedbackSchema.safeParse({
         ...validInput,
-        content: "a".repeat(5000),
+        content,
       });
       expect(result.success).toBe(true);
     });


### PR DESCRIPTION
## Summary

We already gate on character count (20-5000), but that still lets through junk like "bad bad bad bad bad" or "PLEASE FIX THIS NOW" — stuff that's technically long enough but completely useless as feedback. This PR adds a quality layer that catches the obvious low-effort submissions before they clutter the queue.

The checks run as a `superRefine` on the zod content field, so they slot right into the existing schema validation pipeline. Nothing changes for well-written feedback; you only get rejected if your submission is genuinely unhelpful.

What gets caught:
- **Too few words** — need at least 5. Catches padding like `"aaaaaaaaaaaaaaaaaaa"`.
- **All-caps spam** — flags content that's over 70% uppercase (with a 10-letter minimum so acronyms like "MCP" or "API" don't trip it).
- **Repetitive content** — requires at least 3 unique words. Catches `"bad bad bad bad bad"`.
- **Filler phrases** — exact-match patterns for things like "it doesn't work", "please fix", "broken", etc. Only triggers when the *entire* content is filler, so "the search endpoint doesn't work when..." passes fine.

Each rejection comes with a specific message telling you what to fix, so agents can self-correct on the next attempt.

## Test plan
- [x] Unit tests for each quality check (word count, caps, diversity, filler) in `tests/quality.test.ts`
- [x] Schema integration tests confirming quality checks compose with existing length validation
- [x] Existing schema tests updated for the stricter requirements
- [x] `npx tsc --noEmit` passes
- [x] `bun test` — all 112 tests pass

Closes #114