### PR TITLE
Store session ID on every feedback entry

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,6 +120,9 @@ IMPORTANT RULES:
       } else if (args[i] === "--target" && args[i + 1]) {
         conditions.push("target_name = ?");
         params.push(args[++i]);
+      } else if (args[i] === "--session" && args[i + 1]) {
+        conditions.push("session_id = ?");
+        params.push(args[++i]);
       }
     }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -132,13 +132,14 @@ If similar feedback already exists, your submission becomes a vote on it instead
     "suggestion_box_list_feedback",
     `List and filter feedback entries. Use this to review what agents have reported. Default: open items sorted by votes.`,
     listFeedbackSchema.shape,
-    async ({ category, target_type, target_name, status, sort_by, limit }) => {
+    async ({ category, target_type, target_name, status, session_id, sort_by, limit }) => {
       try {
         const items = await store.listFeedback({
           category,
           targetType: target_type,
           targetName: target_name,
           status: status ?? "open",
+          sessionId: session_id,
           sortBy: sort_by,
           limit,
         });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -23,6 +23,7 @@ export const listFeedbackSchema = z.object({
   target_type: z.enum(["mcp_server", "tool", "codebase", "workflow", "general"]).optional().describe("Filter by target type"),
   target_name: z.string().optional().describe("Filter by target name"),
   status: z.enum(["open", "published", "dismissed"]).optional().describe("Filter by status (default: open)"),
+  session_id: z.string().optional().describe("Filter by session ID"),
   sort_by: z.enum(["votes", "recent", "impact"]).optional().describe("Sort order (default: votes)"),
   limit: z.coerce.number().optional().describe("Max results (default: 20)"),
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -142,9 +142,14 @@ export class FeedbackStore {
     if (this.initialized) return;
     await this.withDb(async (db) => {
       await db.exec(SCHEMA);
-      // Migrate existing databases: add title column if missing
+      // Migrate existing databases: add columns if missing
       try {
         await db.exec("ALTER TABLE feedback ADD COLUMN title TEXT");
+      } catch {
+        // Column already exists — ignore
+      }
+      try {
+        await db.exec("ALTER TABLE feedback ADD COLUMN session_id TEXT NOT NULL DEFAULT ''");
       } catch {
         // Column already exists — ignore
       }
@@ -351,6 +356,10 @@ export class FeedbackStore {
       if (input.status) {
         conditions.push("status = ?");
         params.push(input.status);
+      }
+      if (input.sessionId) {
+        conditions.push("session_id = ?");
+        params.push(input.sessionId);
       }
 
       const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface ListFeedbackInput {
   targetType?: TargetType;
   targetName?: string;
   status?: FeedbackStatus;
+  sessionId?: string;
   sortBy?: SortBy;
   limit?: number;
 }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -326,6 +326,33 @@ describe("FeedbackStore", () => {
       await store.close();
     });
 
+    test("filters by sessionId", async () => {
+      const store1 = new FeedbackStore(createConfig(dbPath, { sessionId: "session-a" }));
+      await store1.submitFeedback(SAMPLE_INPUT);
+      await store1.close();
+
+      const store2 = new FeedbackStore(createConfig(dbPath, { sessionId: "session-b" }));
+      await store2.submitFeedback({
+        ...SAMPLE_INPUT,
+        content: "A completely different piece of feedback from another session",
+        targetName: "other-server",
+      });
+      await store2.close();
+
+      const storeRead = new FeedbackStore(createConfig(dbPath));
+      const all = await storeRead.listFeedback();
+      expect(all.length).toBe(2);
+
+      const sessionA = await storeRead.listFeedback({ sessionId: "session-a" });
+      expect(sessionA.length).toBe(1);
+      expect(sessionA[0].sessionId).toBe("session-a");
+
+      const sessionB = await storeRead.listFeedback({ sessionId: "session-b" });
+      expect(sessionB.length).toBe(1);
+      expect(sessionB[0].sessionId).toBe("session-b");
+      await storeRead.close();
+    });
+
     test("respects limit", async () => {
       const store = new FeedbackStore(createConfig(dbPath));
       for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
## Summary

The session_id was already being written on new feedback rows, but existing databases created before the column existed would break, and there was no way to actually query feedback by session. This fills in the gaps:

- Adds an ALTER TABLE migration so databases created before session_id was part of the schema get the column added on init (same pattern as the title column migration)
- Adds a `sessionId` filter to `listFeedback` in the store, the MCP tool schema, and the CLI (`--session` flag)
- Adds test coverage for session-based filtering across multiple store instances

Closes #100

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `bun test` passes (85 tests, including the new session filter test)
- [ ] Manual: create a DB without the session_id column, verify migration adds it on init