### PR TITLE
Add per-session rate limiting

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -12,20 +12,24 @@ import {
 } from "./schemas.js";
 import { checkGhAuth, createGithubIssue } from "./github.js";
 import { assertValidConfig } from "./config.js";
+import { RateLimiter, RateLimitError } from "./rate-limiter.js";
 
 export async function startMcpServer(): Promise<void> {
   const { dataDir, dbPath } = assertValidConfig();
 
   const embed = await createEmbedder();
 
+  const sessionId = randomUUID();
   const store = createFeedbackStore({
     dbPath,
-    sessionId: randomUUID(),
+    sessionId,
     embed,
     persistent: true,
   });
 
   await store.init();
+
+  const rateLimiter = new RateLimiter();
 
   const server = new McpServer({
     name: "suggestion-box",
@@ -56,6 +60,8 @@ If similar feedback already exists, your submission becomes a vote on it instead
     submitFeedbackSchema.shape,
     async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes, git_sha, tool_version }) => {
       try {
+        rateLimiter.check(sessionId);
+
         store.embedPending().catch((e) => console.error("[suggestion-box] embedPending error:", e));
 
         const result = await store.submitFeedback({
@@ -101,6 +107,8 @@ If similar feedback already exists, your submission becomes a vote on it instead
     upvoteFeedbackSchema.shape,
     async ({ feedback_id, evidence, estimated_tokens_saved, estimated_time_saved_minutes }) => {
       try {
+        rateLimiter.check(sessionId);
+
         const result = await store.upvote({
           feedbackId: feedback_id,
           evidence,

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,94 @@
+/**
+ * Simple in-memory sliding-window rate limiter.
+ * Tracks timestamps of actions per session ID and rejects
+ * when the count exceeds the limit within the window.
+ */
+
+export interface RateLimiterConfig {
+  /** Maximum number of submissions allowed within the window (default: 20) */
+  maxSubmissions: number;
+  /** Time window in milliseconds (default: 600_000 = 10 minutes) */
+  windowMs: number;
+}
+
+const DEFAULT_CONFIG: RateLimiterConfig = {
+  maxSubmissions: 20,
+  windowMs: 10 * 60 * 1000, // 10 minutes
+};
+
+export class RateLimitError extends Error {
+  public readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number, limit: number, windowMs: number) {
+    const windowMinutes = Math.round(windowMs / 60_000);
+    const retrySeconds = Math.ceil(retryAfterMs / 1000);
+    super(
+      `Rate limit exceeded: ${limit} submissions per ${windowMinutes} minutes. ` +
+      `Slow down and try again in ${retrySeconds}s.`
+    );
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class RateLimiter {
+  private readonly config: RateLimiterConfig;
+  /** Map of session ID → sorted array of timestamps (ms) */
+  private readonly windows: Map<string, number[]> = new Map();
+
+  constructor(config: Partial<RateLimiterConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Check whether a session is allowed to perform an action.
+   * If allowed, records the action. If not, throws RateLimitError.
+   */
+  check(sessionId: string): void {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+
+    let timestamps = this.windows.get(sessionId);
+    if (!timestamps) {
+      timestamps = [];
+      this.windows.set(sessionId, timestamps);
+    }
+
+    // Prune expired entries
+    const firstValid = timestamps.findIndex((t) => t > cutoff);
+    if (firstValid > 0) {
+      timestamps.splice(0, firstValid);
+    } else if (firstValid === -1) {
+      timestamps.length = 0;
+    }
+
+    if (timestamps.length >= this.config.maxSubmissions) {
+      // The oldest entry in the window determines when a slot opens up
+      const oldestInWindow = timestamps[0];
+      const retryAfterMs = oldestInWindow + this.config.windowMs - now;
+      throw new RateLimitError(retryAfterMs, this.config.maxSubmissions, this.config.windowMs);
+    }
+
+    timestamps.push(now);
+  }
+
+  /**
+   * Get the number of submissions remaining for a session in the current window.
+   */
+  remaining(sessionId: string): number {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+    const timestamps = this.windows.get(sessionId);
+    if (!timestamps) return this.config.maxSubmissions;
+
+    const active = timestamps.filter((t) => t > cutoff).length;
+    return Math.max(0, this.config.maxSubmissions - active);
+  }
+
+  /**
+   * Reset rate limit state for a session (useful for testing).
+   */
+  reset(sessionId: string): void {
+    this.windows.delete(sessionId);
+  }
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,6 @@
 export { FeedbackStore } from "./store.js";
+export { RateLimiter, RateLimitError } from "./rate-limiter.js";
+export type { RateLimiterConfig } from "./rate-limiter.js";
 export type {
   EmbedFn,
   VectorType,

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { RateLimiter, RateLimitError } from "../src/rate-limiter.js";
+
+describe("RateLimiter", () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter({ maxSubmissions: 3, windowMs: 1000 });
+  });
+
+  test("allows submissions under the limit", () => {
+    expect(() => limiter.check("session-1")).not.toThrow();
+    expect(() => limiter.check("session-1")).not.toThrow();
+    expect(() => limiter.check("session-1")).not.toThrow();
+  });
+
+  test("blocks submissions over the limit", () => {
+    limiter.check("session-1");
+    limiter.check("session-1");
+    limiter.check("session-1");
+
+    expect(() => limiter.check("session-1")).toThrow(RateLimitError);
+  });
+
+  test("error message tells the agent to slow down", () => {
+    for (let i = 0; i < 3; i++) limiter.check("session-1");
+
+    try {
+      limiter.check("session-1");
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RateLimitError);
+      const err = e as RateLimitError;
+      expect(err.message).toContain("Rate limit exceeded");
+      expect(err.message).toContain("Slow down");
+      expect(err.retryAfterMs).toBeGreaterThan(0);
+    }
+  });
+
+  test("tracks sessions independently", () => {
+    for (let i = 0; i < 3; i++) limiter.check("session-1");
+
+    // session-2 should still be fine
+    expect(() => limiter.check("session-2")).not.toThrow();
+  });
+
+  test("allows submissions after window expires", async () => {
+    const shortLimiter = new RateLimiter({ maxSubmissions: 2, windowMs: 50 });
+    shortLimiter.check("s1");
+    shortLimiter.check("s1");
+
+    expect(() => shortLimiter.check("s1")).toThrow(RateLimitError);
+
+    // Wait for window to expire
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(() => shortLimiter.check("s1")).not.toThrow();
+  });
+
+  test("remaining() returns correct count", () => {
+    expect(limiter.remaining("session-1")).toBe(3);
+
+    limiter.check("session-1");
+    expect(limiter.remaining("session-1")).toBe(2);
+
+    limiter.check("session-1");
+    expect(limiter.remaining("session-1")).toBe(1);
+
+    limiter.check("session-1");
+    expect(limiter.remaining("session-1")).toBe(0);
+  });
+
+  test("remaining() returns full limit for unknown sessions", () => {
+    expect(limiter.remaining("unknown")).toBe(3);
+  });
+
+  test("reset() clears session state", () => {
+    for (let i = 0; i < 3; i++) limiter.check("session-1");
+    expect(limiter.remaining("session-1")).toBe(0);
+
+    limiter.reset("session-1");
+    expect(limiter.remaining("session-1")).toBe(3);
+  });
+
+  test("uses default config when none provided", () => {
+    const defaultLimiter = new RateLimiter();
+    // Default is 20 per 10 minutes — should allow 20
+    for (let i = 0; i < 20; i++) {
+      expect(() => defaultLimiter.check("s")).not.toThrow();
+    }
+    expect(() => defaultLimiter.check("s")).toThrow(RateLimitError);
+  });
+
+  test("sliding window evicts old entries", async () => {
+    const slidingLimiter = new RateLimiter({ maxSubmissions: 2, windowMs: 80 });
+
+    slidingLimiter.check("s1"); // t=0
+    await new Promise((r) => setTimeout(r, 50));
+    slidingLimiter.check("s1"); // t=50
+
+    // At t=50, both entries are within the 80ms window → limit reached
+    expect(() => slidingLimiter.check("s1")).toThrow(RateLimitError);
+
+    // Wait for the first entry to expire (t=0 + 80ms = 80ms, we're at ~90ms)
+    await new Promise((r) => setTimeout(r, 40));
+
+    // Now the first entry should be evicted, freeing a slot
+    expect(() => slidingLimiter.check("s1")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Agents can get into loops and flood the suggestion-box DB with submissions. This adds a simple in-memory sliding-window rate limiter that caps how many submissions a single session can make within a time window (20 per 10 minutes by default). When an agent hits the limit, it gets a clear error message telling it to slow down, along with how many seconds to wait before retrying.

- Rate limiting applies to both `submit_feedback` and `upvote_feedback` MCP tools
- The `RateLimiter` class is also exported from the SDK so programmatic users can use it directly
- Read-only operations (list, status, dismiss, publish) are not rate-limited

## Test plan

- [x] Unit tests cover: allow under limit, block over limit, sliding window expiry, independent session tracking, reset, default config, clear error messages
- [x] `npx tsc --noEmit` passes
- [x] `bun test` passes (94 tests, 0 failures)

Closes #112