### PR TITLE
Tie feedback entries to git SHA at submission time

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -212,6 +212,7 @@ IMPORTANT RULES:
       updatedAt: row.updated_at,
       publishedIssueUrl: row.published_issue_url,
       sessionId: row.session_id,
+      gitSha: row.git_sha ?? null,
     }, voteRows);
 
     const now = Math.floor(Date.now() / 1000);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -54,7 +54,7 @@ Use category "observation" when:
 
 If similar feedback already exists, your submission becomes a vote on it instead of creating a duplicate. Include impact estimates to help prioritize.`,
     submitFeedbackSchema.shape,
-    async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes }) => {
+    async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes, git_sha }) => {
       try {
         store.embedPending().catch((e) => console.error("[suggestion-box] embedPending error:", e));
 
@@ -67,6 +67,7 @@ If similar feedback already exists, your submission becomes a vote on it instead
           githubRepo: github_repo,
           estimatedTokensSaved: estimated_tokens_saved,
           estimatedTimeSavedMinutes: estimated_time_saved_minutes,
+          gitSha: git_sha,
         });
 
         if (result.isDuplicate) {
@@ -151,6 +152,7 @@ If similar feedback already exists, your submission becomes a vote on it instead
           text += `ID: ${item.id}\n`;
           text += `Target: ${item.targetType}/${item.targetName}`;
           if (item.githubRepo) text += ` (repo: ${item.githubRepo})`;
+          if (item.gitSha) text += ` (sha: ${item.gitSha.slice(0, 8)})`;
           text += `\n${item.content}\n\n`;
         }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,6 +19,7 @@ export const submitFeedbackSchema = z.object({
   github_repo: z.string().optional().describe("GitHub repo for publishing (e.g., 'owner/repo')"),
   estimated_tokens_saved: z.coerce.number().optional().describe("Estimated tokens this improvement would save per occurrence"),
   estimated_time_saved_minutes: z.coerce.number().optional().describe("Estimated minutes this improvement would save per occurrence"),
+  git_sha: z.string().optional().describe("Git HEAD SHA at time of feedback (auto-detected if omitted)"),
 });
 
 export const upvoteFeedbackSchema = z.object({

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { connect } from "@tursodatabase/database";
 import { randomUUID } from "crypto";
+import { execSync } from "child_process";
 import { isTrigramMode, trigramSimilarity, DEFAULT_TRIGRAM_THRESHOLD } from "./embedder.js";
 import type {
   SupervisorConfig,
@@ -37,7 +38,8 @@ CREATE TABLE IF NOT EXISTS feedback (
     created_at                  INTEGER NOT NULL,
     updated_at                  INTEGER NOT NULL,
     published_issue_url         TEXT,
-    session_id                  TEXT NOT NULL
+    session_id                  TEXT NOT NULL,
+    git_sha                     TEXT
 );
 
 CREATE TABLE IF NOT EXISTS vote_log (
@@ -142,19 +144,32 @@ export class FeedbackStore {
     if (this.initialized) return;
     await this.withDb(async (db) => {
       await db.exec(SCHEMA);
-      // Migrate existing databases: add columns if missing
-      try {
-        await db.exec("ALTER TABLE feedback ADD COLUMN title TEXT");
-      } catch {
-        // Column already exists — ignore
-      }
-      try {
-        await db.exec("ALTER TABLE feedback ADD COLUMN session_id TEXT NOT NULL DEFAULT ''");
-      } catch {
-        // Column already exists — ignore
+      // Migrate existing databases: add missing columns
+      for (const migration of [
+        "ALTER TABLE feedback ADD COLUMN title TEXT",
+        "ALTER TABLE feedback ADD COLUMN git_sha TEXT",
+        "ALTER TABLE feedback ADD COLUMN session_id TEXT NOT NULL DEFAULT ''",
+      ]) {
+        try {
+          await db.exec(migration);
+        } catch {
+          // Column already exists — ignore
+        }
       }
     });
     this.initialized = true;
+  }
+
+  /**
+   * Resolve the current git HEAD SHA. Returns null if not in a git repo
+   * or if git is unavailable.
+   */
+  private resolveGitSha(): string | null {
+    try {
+      return execSync("git rev-parse HEAD", { encoding: "utf-8", timeout: 5000 }).trim() || null;
+    } catch {
+      return null;
+    }
   }
 
   private get vfn(): string {
@@ -164,6 +179,7 @@ export class FeedbackStore {
   async submitFeedback(input: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {
     await this.init();
     const now = Math.floor(Date.now() / 1000);
+    const gitSha = input.gitSha ?? this.resolveGitSha();
 
     const duplicate = this.useTrigramDedup
       ? await this.findSimilarByTrigram(input.content, input.targetType, input.targetName)
@@ -193,13 +209,13 @@ export class FeedbackStore {
 
     await this.withDb(async (db) => {
       await db.prepare(
-        `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?)`
+        `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id, git_sha)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?, ?)`
       ).run(
         id, input.title ?? null, input.content, embedding ? vecBuf(embedding) : null, input.category, input.targetType,
         input.targetName, input.githubRepo ?? null,
         input.estimatedTokensSaved ?? null, input.estimatedTimeSavedMinutes ?? null,
-        now, now, this.sessionId
+        now, now, this.sessionId, gitSha
       );
 
       await db.prepare(
@@ -284,6 +300,7 @@ export class FeedbackStore {
       updatedAt: row.updated_at,
       publishedIssueUrl: row.published_issue_url,
       sessionId: row.session_id,
+      gitSha: row.git_sha ?? null,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface Feedback {
   updatedAt: number;
   publishedIssueUrl: string | null;
   sessionId: string;
+  gitSha: string | null;
 }
 
 export interface SubmitFeedbackInput {
@@ -54,6 +55,7 @@ export interface SubmitFeedbackInput {
   githubRepo?: string;
   estimatedTokensSaved?: number;
   estimatedTimeSavedMinutes?: number;
+  gitSha?: string;
 }
 
 export interface SubmitFeedbackResult {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -19,6 +19,7 @@ function makeFeedback(overrides: Partial<Feedback> = {}): Feedback {
     updatedAt: 1000,
     publishedIssueUrl: null,
     sessionId: "test-session",
+    gitSha: null,
     ...overrides,
   };
 }

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -150,6 +150,17 @@ describe("submitFeedbackSchema", () => {
         expect(result.data.estimated_time_saved_minutes).toBe(5);
       }
     });
+
+    test("accepts optional git_sha", () => {
+      const result = submitFeedbackSchema.safeParse({
+        ...validInput,
+        git_sha: "abc123def456",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.git_sha).toBe("abc123def456");
+      }
+    });
   });
 });
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -96,6 +96,29 @@ describe("FeedbackStore", () => {
       expect(feedback!.estimatedTokensSaved).toBe(500);
       expect(feedback!.estimatedTimeSavedMinutes).toBe(10);
       expect(feedback!.sessionId).toBe("test-session");
+      expect(feedback!.gitSha).toBeTypeOf("string"); // auto-detected from git repo
+      await store.close();
+    });
+
+    test("stores explicit git_sha when provided", async () => {
+      const store = new FeedbackStore(createConfig(dbPath));
+      const result = await store.submitFeedback({
+        ...SAMPLE_INPUT,
+        gitSha: "abc123def456",
+      });
+
+      const feedback = await store.getFeedbackById(result.feedbackId);
+      expect(feedback!.gitSha).toBe("abc123def456");
+      await store.close();
+    });
+
+    test("auto-detects git SHA when not provided", async () => {
+      const store = new FeedbackStore(createConfig(dbPath));
+      const result = await store.submitFeedback(SAMPLE_INPUT);
+
+      const feedback = await store.getFeedbackById(result.feedbackId);
+      // We're running inside a git repo, so SHA should be a 40-char hex string
+      expect(feedback!.gitSha).toMatch(/^[0-9a-f]{40}$/);
       await store.close();
     });
   });


### PR DESCRIPTION
Closes #118

When you submit feedback, the tool now captures whatever commit you're sitting on and saves it alongside the entry. This is the groundwork for eventually being able to say "hey, the code changed since this feedback was filed — maybe re-evaluate it."

## What changed

- New `git_sha` column on the feedback table, with an ALTER TABLE migration for existing databases
- On submit, we shell out to `git rev-parse HEAD` to grab the current SHA. If you're not in a git repo or git isn't available, it just stores null — no crashes, no fuss
- The MCP schema accepts an optional `git_sha` parameter so callers can override the auto-detection if they want
- List output now shows a short SHA prefix next to the target info when available

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 87 tests pass (`bun test`)
- [x] New tests verify auto-detection produces a valid 40-char hex SHA (since we're in a git repo)
- [x] New test confirms explicit `gitSha` input is stored as-is
- [x] Schema test covers the new optional `git_sha` field
- [ ] Smoke test: run the MCP server, submit feedback, confirm `git_sha` shows up in list output