### PR TITLE
Capture version metadata on feedback submissions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,15 @@ IMPORTANT RULES:
       console.log(`--- [${r.category}] ${r.status} | ${r.votes} votes | ${timeAgo(r.created_at)} ---`);
       console.log(`ID: ${r.id}`);
       console.log(`Target: ${r.target_type}/${r.target_name}${r.github_repo ? ` (repo: ${r.github_repo})` : ""}`);
+      if (r.metadata) {
+        try {
+          const meta = JSON.parse(r.metadata);
+          const parts: string[] = [];
+          if (meta.suggestionBoxVersion) parts.push(`sb@${meta.suggestionBoxVersion}`);
+          if (meta.toolVersion) parts.push(`tool@${meta.toolVersion}`);
+          if (parts.length > 0) console.log(`Versions: ${parts.join(", ")}`);
+        } catch {}
+      }
       console.log(r.content.slice(0, 500));
       if (r.content.length > 500) console.log(`  ...(${r.content.length} chars total)`);
       console.log();
@@ -196,6 +205,11 @@ IMPORTANT RULES:
       "SELECT session_id, evidence, estimated_tokens_saved, estimated_time_saved_minutes, created_at FROM vote_log WHERE feedback_id = ?"
     ).all(feedbackId) as any[];
 
+    let metadata = null;
+    if (row.metadata) {
+      try { metadata = JSON.parse(row.metadata); } catch {}
+    }
+
     const result = createGithubIssue(repo, {
       id: row.id,
       title: row.title ?? null,
@@ -213,6 +227,7 @@ IMPORTANT RULES:
       publishedIssueUrl: row.published_issue_url,
       sessionId: row.session_id,
       gitSha: row.git_sha ?? null,
+      metadata,
     }, voteRows);
 
     const now = Math.floor(Date.now() / 1000);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -54,7 +54,7 @@ Use category "observation" when:
 
 If similar feedback already exists, your submission becomes a vote on it instead of creating a duplicate. Include impact estimates to help prioritize.`,
     submitFeedbackSchema.shape,
-    async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes, git_sha }) => {
+    async ({ category, title, content, target_type, target_name, github_repo, estimated_tokens_saved, estimated_time_saved_minutes, git_sha, tool_version }) => {
       try {
         store.embedPending().catch((e) => console.error("[suggestion-box] embedPending error:", e));
 
@@ -68,6 +68,7 @@ If similar feedback already exists, your submission becomes a vote on it instead
           estimatedTokensSaved: estimated_tokens_saved,
           estimatedTimeSavedMinutes: estimated_time_saved_minutes,
           gitSha: git_sha,
+          toolVersion: tool_version,
         });
 
         if (result.isDuplicate) {
@@ -153,7 +154,14 @@ If similar feedback already exists, your submission becomes a vote on it instead
           text += `Target: ${item.targetType}/${item.targetName}`;
           if (item.githubRepo) text += ` (repo: ${item.githubRepo})`;
           if (item.gitSha) text += ` (sha: ${item.gitSha.slice(0, 8)})`;
-          text += `\n${item.content}\n\n`;
+          text += "\n";
+          if (item.metadata) {
+            const vParts: string[] = [];
+            if (item.metadata.suggestionBoxVersion) vParts.push(`sb@${item.metadata.suggestionBoxVersion}`);
+            if (item.metadata.toolVersion) vParts.push(`tool@${item.metadata.toolVersion}`);
+            if (vParts.length > 0) text += `Versions: ${vParts.join(", ")}\n`;
+          }
+          text += `${item.content}\n\n`;
         }
 
         return { content: [{ type: "text" as const, text }] };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -20,6 +20,7 @@ export const submitFeedbackSchema = z.object({
   estimated_tokens_saved: z.coerce.number().optional().describe("Estimated tokens this improvement would save per occurrence"),
   estimated_time_saved_minutes: z.coerce.number().optional().describe("Estimated minutes this improvement would save per occurrence"),
   git_sha: z.string().optional().describe("Git HEAD SHA at time of feedback (auto-detected if omitted)"),
+  tool_version: z.string().optional().describe("Version of the target tool, if known (e.g., '1.2.3')"),
 });
 
 export const upvoteFeedbackSchema = z.object({

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -8,6 +8,7 @@ export type {
   SortBy,
   SupervisorConfig,
   Feedback,
+  FeedbackMetadata,
   SubmitFeedbackInput,
   SubmitFeedbackResult,
   UpvoteInput,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,9 +2,11 @@ import { connect } from "@tursodatabase/database";
 import { randomUUID } from "crypto";
 import { execSync } from "child_process";
 import { isTrigramMode, trigramSimilarity, DEFAULT_TRIGRAM_THRESHOLD } from "./embedder.js";
+import { getSuggestionBoxVersion } from "./version.js";
 import type {
   SupervisorConfig,
   Feedback,
+  FeedbackMetadata,
   FeedbackStatus,
   SubmitFeedbackInput,
   SubmitFeedbackResult,
@@ -39,7 +41,8 @@ CREATE TABLE IF NOT EXISTS feedback (
     updated_at                  INTEGER NOT NULL,
     published_issue_url         TEXT,
     session_id                  TEXT NOT NULL,
-    git_sha                     TEXT
+    git_sha                     TEXT,
+    metadata                    TEXT
 );
 
 CREATE TABLE IF NOT EXISTS vote_log (
@@ -149,6 +152,7 @@ export class FeedbackStore {
         "ALTER TABLE feedback ADD COLUMN title TEXT",
         "ALTER TABLE feedback ADD COLUMN git_sha TEXT",
         "ALTER TABLE feedback ADD COLUMN session_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE feedback ADD COLUMN metadata TEXT",
       ]) {
         try {
           await db.exec(migration);
@@ -207,15 +211,23 @@ export class FeedbackStore {
     const id = randomUUID();
     const embedding = this.useTrigramDedup ? null : await this.embed(input.content);
 
+    const metadata: FeedbackMetadata = {
+      suggestionBoxVersion: getSuggestionBoxVersion(),
+    };
+    if (input.toolVersion) {
+      metadata.toolVersion = input.toolVersion;
+    }
+    const metadataJson = JSON.stringify(metadata);
+
     await this.withDb(async (db) => {
       await db.prepare(
-        `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id, git_sha)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO feedback (id, title, content, embedding, category, target_type, target_name, github_repo, status, votes, estimated_tokens_saved, estimated_time_saved_minutes, created_at, updated_at, session_id, git_sha, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', 1, ?, ?, ?, ?, ?, ?, ?)`
       ).run(
         id, input.title ?? null, input.content, embedding ? vecBuf(embedding) : null, input.category, input.targetType,
         input.targetName, input.githubRepo ?? null,
         input.estimatedTokensSaved ?? null, input.estimatedTimeSavedMinutes ?? null,
-        now, now, this.sessionId, gitSha
+        now, now, this.sessionId, gitSha, metadataJson
       );
 
       await db.prepare(
@@ -284,6 +296,15 @@ export class FeedbackStore {
   }
 
   private rowToFeedback(row: any): Feedback {
+    let metadata: FeedbackMetadata | null = null;
+    if (row.metadata) {
+      try {
+        metadata = JSON.parse(row.metadata);
+      } catch {
+        // Corrupted JSON — treat as null
+      }
+    }
+
     return {
       id: row.id,
       title: row.title ?? null,
@@ -301,6 +322,7 @@ export class FeedbackStore {
       publishedIssueUrl: row.published_issue_url,
       sessionId: row.session_id,
       gitSha: row.git_sha ?? null,
+      metadata,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,16 @@ export interface SupervisorConfig {
   persistent?: boolean;
 }
 
+/** Version metadata captured at feedback submission time. */
+export interface FeedbackMetadata {
+  /** suggestion-box version that created this entry */
+  suggestionBoxVersion?: string;
+  /** Version of the target tool, if known */
+  toolVersion?: string;
+  /** Any additional key-value pairs */
+  [key: string]: unknown;
+}
+
 export interface Feedback {
   id: string;
   title: string | null;
@@ -44,6 +54,7 @@ export interface Feedback {
   publishedIssueUrl: string | null;
   sessionId: string;
   gitSha: string | null;
+  metadata: FeedbackMetadata | null;
 }
 
 export interface SubmitFeedbackInput {
@@ -56,6 +67,7 @@ export interface SubmitFeedbackInput {
   estimatedTokensSaved?: number;
   estimatedTimeSavedMinutes?: number;
   gitSha?: string;
+  toolVersion?: string;
 }
 
 export interface SubmitFeedbackResult {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+let cachedVersion: string | undefined;
+
+/**
+ * Read the suggestion-box version from our own package.json.
+ * Falls back to "unknown" if the file can't be read.
+ */
+export function getSuggestionBoxVersion(): string {
+  if (cachedVersion) return cachedVersion;
+
+  try {
+    // Walk up from this file to find package.json
+    const thisDir = dirname(fileURLToPath(import.meta.url));
+    // In dist/ or src/, package.json is one level up
+    const pkgPath = resolve(thisDir, "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    cachedVersion = pkg.version ?? "unknown";
+  } catch {
+    cachedVersion = "unknown";
+  }
+
+  return cachedVersion!;
+}

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -20,6 +20,7 @@ function makeFeedback(overrides: Partial<Feedback> = {}): Feedback {
     publishedIssueUrl: null,
     sessionId: "test-session",
     gitSha: null,
+    metadata: null,
     ...overrides,
   };
 }

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -161,6 +161,25 @@ describe("submitFeedbackSchema", () => {
         expect(result.data.git_sha).toBe("abc123def456");
       }
     });
+
+    test("accepts optional tool_version", () => {
+      const result = submitFeedbackSchema.safeParse({
+        ...validInput,
+        tool_version: "1.2.3",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tool_version).toBe("1.2.3");
+      }
+    });
+
+    test("tool_version is optional", () => {
+      const result = submitFeedbackSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tool_version).toBeUndefined();
+      }
+    });
   });
 });
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -121,6 +121,40 @@ describe("FeedbackStore", () => {
       expect(feedback!.gitSha).toMatch(/^[0-9a-f]{40}$/);
       await store.close();
     });
+
+    test("captures metadata with suggestion-box version", async () => {
+      const store = new FeedbackStore(createConfig(dbPath));
+      const result = await store.submitFeedback(SAMPLE_INPUT);
+
+      const feedback = await store.getFeedbackById(result.feedbackId);
+      expect(feedback!.metadata).not.toBeNull();
+      expect(feedback!.metadata!.suggestionBoxVersion).toBeTruthy();
+      await store.close();
+    });
+
+    test("captures tool version when provided", async () => {
+      const store = new FeedbackStore(createConfig(dbPath));
+      const result = await store.submitFeedback({
+        ...SAMPLE_INPUT,
+        toolVersion: "2.5.0",
+      });
+
+      const feedback = await store.getFeedbackById(result.feedbackId);
+      expect(feedback!.metadata).not.toBeNull();
+      expect(feedback!.metadata!.toolVersion).toBe("2.5.0");
+      expect(feedback!.metadata!.suggestionBoxVersion).toBeTruthy();
+      await store.close();
+    });
+
+    test("metadata omits toolVersion when not provided", async () => {
+      const store = new FeedbackStore(createConfig(dbPath));
+      const result = await store.submitFeedback(SAMPLE_INPUT);
+
+      const feedback = await store.getFeedbackById(result.feedbackId);
+      expect(feedback!.metadata).not.toBeNull();
+      expect(feedback!.metadata!.toolVersion).toBeUndefined();
+      await store.close();
+    });
   });
 
   describe("trigram dedup", () => {


### PR DESCRIPTION
## Summary

Every feedback entry now records which version of suggestion-box created it, and callers can optionally pass the target tool's version too. This lands as a `metadata` JSON column on the feedback table -- flexible enough to carry additional context down the road without more schema migrations.

- Suggestion-box version is captured automatically from package.json on every `submitFeedback` call
- New optional `tool_version` parameter on the MCP submit tool lets agents report what version of the tool they're filing feedback about
- `list` output (both CLI and MCP) shows version info when present
- Existing databases get the column via the same ALTER TABLE migration pattern we already use for `title`

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 89 tests pass (`bun test`), including 5 new ones covering metadata capture, tool version round-trip, and schema validation
- [ ] Manual: submit feedback via MCP, verify metadata JSON in DB
- [ ] Manual: submit with `tool_version`, confirm it shows in `list` output

Closes #128