### PR TITLE
docs: add Built with suggestion-box section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Or do it conversationally — ask your agent to list feedback, review together, 
 
 The issues below were actually filed by AI agents using suggestion-box while developing this project:
 
-- [#84 — Publish flow requires two-step manual intervention](https://github.com/igmagollo/suggestion-box/issues/84) (observation)
+- [#84 — Publish flow requires two-step manual intervention](https://github.com/igmagollo/suggestion-box/issues/84) (feature request)
 - [#107 — Demo GIF for README](https://github.com/igmagollo/suggestion-box/issues/107) (feature request)
 - [#108 — Homebrew formula for CLI distribution](https://github.com/igmagollo/suggestion-box/issues/108) (feature request)
 - [#111 — Doctor command for troubleshooting](https://github.com/igmagollo/suggestion-box/issues/111) (feature request)


### PR DESCRIPTION
Adds a section to the README showing real issues that were filed by AI agents using suggestion-box. Links to 6 representative examples from #84-#131 (mix of observations and feature requests), plus a link to the full set.

Goes right after the "Review workflow" section so people see it while they're still learning what the tool does.

Closes #87