### PR TITLE
feat(cli): add doctor command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -546,7 +546,7 @@ enabled = true
   }
 
 } else if (command === "doctor") {
-  const { validateConfig } = await import("./config.js");
+  const { accessSync, constants: fsConstants } = await import("fs");
   const { execFileSync } = await import("child_process");
 
   interface CheckResult {
@@ -557,22 +557,26 @@ enabled = true
 
   const checks: CheckResult[] = [];
 
-  // 1. Data directory check
-  const configResult = validateConfig();
-  if (configResult.valid && existsSync(configResult.dataDir)) {
-    checks.push({ name: "Data directory", passed: true, message: `${configResult.dataDir} exists and is writable` });
-  } else if (!existsSync(configResult.dataDir)) {
-    checks.push({ name: "Data directory", passed: false, message: `${configResult.dataDir} does not exist. Run 'suggestion-box init' first.` });
+  // 1. Data directory check (read-only — no side effects)
+  const dataDir = resolve(process.env.SUGGESTION_BOX_DIR ?? ".suggestion-box");
+  if (existsSync(dataDir)) {
+    try {
+      accessSync(dataDir, fsConstants.R_OK | fsConstants.W_OK);
+      checks.push({ name: "Data directory", passed: true, message: `${dataDir} exists and is writable` });
+    } catch {
+      checks.push({ name: "Data directory", passed: false, message: `${dataDir} exists but is not writable. Check permissions.` });
+    }
   } else {
-    checks.push({ name: "Data directory", passed: false, message: configResult.errors.join("; ") });
+    checks.push({ name: "Data directory", passed: false, message: `${dataDir} does not exist. Run 'suggestion-box init' first.` });
   }
 
   // 2. Database check
   const dbPath = getDbPath();
   if (existsSync(dbPath)) {
+    let db: any = null;
     try {
       const { connect } = await import("@tursodatabase/database");
-      const db = await connect(dbPath);
+      db = await connect(dbPath);
       await db.exec("SELECT 1");
       checks.push({ name: "Database", passed: true, message: `${dbPath} is accessible` });
 
@@ -588,11 +592,11 @@ enabled = true
       } catch (e: any) {
         checks.push({ name: "WAL mode", passed: false, message: `Could not check journal_mode: ${e.message}` });
       }
-
-      db.close();
     } catch (e: any) {
       checks.push({ name: "Database", passed: false, message: `Cannot open ${dbPath}: ${e.message}` });
       checks.push({ name: "WAL mode", passed: false, message: "Skipped (database not accessible)" });
+    } finally {
+      db?.close();
     }
   } else {
     checks.push({ name: "Database", passed: false, message: `${dbPath} not found. Run 'suggestion-box init' and start the server once to create it.` });


### PR DESCRIPTION
## Summary

- Adds `suggestion-box doctor` that runs 7 environment health checks: data dir, database, WAL mode, gh CLI auth, embedding model, agent configs, and SessionStart hook
- Each check prints a pass/fail line with actionable context on failure
- Exits 0 if everything's green, 1 if anything fails

Closes #111

## Test plan

- [ ] Run `suggestion-box doctor` in an initialized project, verify all checks pass
- [ ] Run it in a fresh directory (no init), verify it reports missing data dir, db, configs, hooks
- [ ] Uninstall gh CLI or log out, confirm it catches the right failure mode
- [ ] Check `suggestion-box help` includes the new command