### PR TITLE
feat(init): ship pre-authorized tool list in Claude Code settings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -417,7 +417,9 @@ enabled = true
       settings.permissions.allow.push(...missingTools);
     }
 
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+    if (!hasHook || missingTools.length > 0) {
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+    }
     if (!hasHook) {
       console.log("  Installed SessionStart hook (.claude/settings.json)");
     }


### PR DESCRIPTION
## Summary

- `init` now adds the 5 safe suggestion-box tools to `permissions.allow` in `.claude/settings.json`, so they don't pop up confirmation dialogs every time
- `publish_to_github` is intentionally left out since it creates public issues
- `uninit` cleans up the entries, same as it does for the hook
- `--dry-run` reports what would be added

Merges cleanly with existing `permissions.allow` entries if there are any.

Closes #106