### PR TITLE
fix(github): use generic bracket pattern to detect suggestion-box issue titles

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -45,6 +45,17 @@ export function keywordSimilarity(keywords: string, title: string): number {
   return intersection / union;
 }
 
+/**
+ * Returns true if a GitHub issue title looks like it was created by suggestion-box.
+ * Suggestion-box always formats titles as `[<category label>] <summary>`, so any
+ * title matching the pattern `[...] ` (bracket-wrapped tag at the start) is treated
+ * as a suggestion-box issue and excluded from dedup candidates.
+ * This handles both built-in categories and arbitrary custom categories.
+ */
+export function isSuggestionBoxIssueTitle(title: string): boolean {
+  return /^\[.+\] /.test(title);
+}
+
 function searchExistingIssues(repo: string, keywords: string): ExistingIssue | null {
   try {
     const raw = execFileSync(
@@ -53,10 +64,8 @@ function searchExistingIssues(repo: string, keywords: string): ExistingIssue | n
       { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
     );
     const issues: ExistingIssue[] = JSON.parse(raw.trim() || "[]");
-    // Skip issues created by suggestion-box, then pick best match above similarity threshold
-    const candidates = issues.filter((i) =>
-      !i.title.includes("[Friction Report]") && !i.title.includes("[Feature Request]") && !i.title.includes("[Observation]")
-    );
+    // Skip issues created by suggestion-box (any category), then pick best match above similarity threshold
+    const candidates = issues.filter((i) => !isSuggestionBoxIssueTitle(i.title));
     const SIMILARITY_THRESHOLD = 0.3;
     for (const candidate of candidates) {
       if (keywordSimilarity(keywords, candidate.title) >= SIMILARITY_THRESHOLD) {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { extractKeywords, keywordSimilarity } from "../src/github.js";
+import { extractKeywords, keywordSimilarity, isSuggestionBoxIssueTitle } from "../src/github.js";
 import type { Feedback } from "../src/types.js";
 
 function makeFeedback(overrides: Partial<Feedback> = {}): Feedback {
@@ -75,6 +75,41 @@ describe("extractKeywords", () => {
     const keywords = extractKeywords(feedback);
     const words = keywords.split(" ");
     expect(words.length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("isSuggestionBoxIssueTitle", () => {
+  test("detects built-in friction category title", () => {
+    expect(isSuggestionBoxIssueTitle("[Friction Report] Tool crashes on startup")).toBe(true);
+  });
+
+  test("detects built-in feature request category title", () => {
+    expect(isSuggestionBoxIssueTitle("[Feature Request] Add dark mode support")).toBe(true);
+  });
+
+  test("detects built-in observation category title", () => {
+    expect(isSuggestionBoxIssueTitle("[Observation] Memory usage increases over time")).toBe(true);
+  });
+
+  test("detects custom category titles", () => {
+    expect(isSuggestionBoxIssueTitle("[bug] Login page throws 500 error")).toBe(true);
+    expect(isSuggestionBoxIssueTitle("[performance] Slow query on dashboard")).toBe(true);
+    expect(isSuggestionBoxIssueTitle("[security_issue] Token exposed in logs")).toBe(true);
+  });
+
+  test("does not match regular issue titles", () => {
+    expect(isSuggestionBoxIssueTitle("Fix the login bug")).toBe(false);
+    expect(isSuggestionBoxIssueTitle("Add dark mode")).toBe(false);
+    expect(isSuggestionBoxIssueTitle("Memory leak in worker")).toBe(false);
+  });
+
+  test("does not match titles with brackets but no trailing space", () => {
+    // '[tag]text' without a space after the bracket is not the suggestion-box format
+    expect(isSuggestionBoxIssueTitle("[bug]Login issue")).toBe(false);
+  });
+
+  test("does not match empty bracket pairs", () => {
+    expect(isSuggestionBoxIssueTitle("[] empty tag")).toBe(false);
   });
 });
 


### PR DESCRIPTION
The dedup filter in `searchExistingIssues` was checking for `[Friction Report]`, `[Feature Request]`, and `[Observation]` by name to skip suggestion-box-created issues. That breaks with custom categories since those titles never match any of the hardcoded strings, so they'd be treated as external issues and incorrectly matched against.

The fix is a single regex: `^\[.+\] `. Any suggestion-box issue title starts with a bracket-wrapped label followed by a space, so this covers all categories without needing to know what they are. Hardcoded list is gone. Future categories just work.

Added `isSuggestionBoxIssueTitle` as an exported function so it can be tested directly. 7 new tests covering built-ins, custom categories, and the edge cases (no trailing space, empty brackets, plain titles).

Closes #148