### PR TITLE
feat(hook): inject top-voted friction digest into SessionStart

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,13 +71,13 @@ if (command === "hook") {
     // Gracefully skip if the DB doesn't exist or is locked by the MCP server.
     let frictionDigest = "";
     const dbPath = getDbPath();
-    if (existsSync(dbPath)) {
+    if (cats.includes("friction") && existsSync(dbPath)) {
       try {
         const { connect } = await import("@tursodatabase/database");
         const db = await connect(dbPath);
         try {
           await db.exec("PRAGMA journal_mode=WAL");
-          await db.exec("PRAGMA busy_timeout = 1000");
+          await db.exec("PRAGMA busy_timeout = 5000");
           const rows = await db.prepare(
             "SELECT title, content, votes, target_type, target_name FROM feedback WHERE status = 'open' AND category = 'friction' ORDER BY votes DESC LIMIT 5"
           ).all() as any[];


### PR DESCRIPTION
When a new agent session starts, they now see the top 5 open friction items right in the hook output — before they do anything. Means they don't have to rediscover known issues the hard way.

The digest shows title (if set) or a truncated content preview, vote count, and target. It's filtered to `friction` category and `open` status, sorted by votes.

If the DB doesn't exist yet or is locked by the MCP server, it silently skips. No failure, no noise.

Example output when there's data:

```
KNOWN FRICTION (top-voted open issues — avoid repeating these mistakes):
  1. [3 votes] mcp_server/context7: Context7 returns empty results without explanation
  2. [2 votes] tool/gh CLI: gh CLI truncates large PR diffs unexpectedly
```

Closes #119