### PR TITLE
feat: add /review slash command for conversational feedback triage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ const ALLOWED_TOOLS = [
   "mcp__suggestion-box__suggestion_box_list_feedback",
   "mcp__suggestion-box__suggestion_box_status",
   "mcp__suggestion-box__suggestion_box_dismiss_feedback",
+  "mcp__suggestion-box__suggestion_box_publish_to_github",
 ];
 
 function getCliCommand(): { command: string; args: string[] } {
@@ -499,6 +500,36 @@ enabled = true
     }
   }
 
+  // .claude/commands/suggestion-box/review.md — /review slash command
+  const commandsDir = join(claudeSettingsDir, "commands", "suggestion-box");
+  const reviewCmdPath = join(commandsDir, "review.md");
+  const reviewCmdContent = `---
+description: Triage all open suggestion-box feedback — publish, dismiss, or skip each item
+---
+Run the suggestion-box review flow: list all open feedback and triage each item one by one.
+
+Use the \`suggestion_box_list_feedback\` MCP tool (status: open, sort_by: votes) to load the queue, then for each item ask the user: **publish**, **dismiss**, **skip**, or **quit**.
+
+- **publish** → call \`suggestion_box_publish_to_github\` (ask for \`github_repo\` if missing)
+- **dismiss** → call \`suggestion_box_dismiss_feedback\`
+- **skip** → leave unchanged, move on
+- **quit** → stop and show summary
+
+After finishing, show a summary: how many published, dismissed, skipped, and links to any issues created.
+
+Tip: observation-category items rarely warrant a public GitHub issue — mention this when you encounter them.
+`;
+
+  if (dryRun) {
+    console.log(`${prefix}Would create .claude/commands/suggestion-box/review.md (/review slash command)`);
+  } else {
+    if (!existsSync(commandsDir)) mkdirSync(commandsDir, { recursive: true });
+    if (!existsSync(reviewCmdPath)) {
+      writeFileSync(reviewCmdPath, reviewCmdContent);
+      console.log("  Wrote .claude/commands/suggestion-box/review.md (/suggestion-box:review slash command)");
+    }
+  }
+
   if (dryRun) {
     console.log(`\n${prefix}No files were modified.`);
   } else {
@@ -629,6 +660,26 @@ enabled = true
         removed++;
       }
     } catch {}
+  }
+
+  // Remove .claude/commands/suggestion-box/review.md
+  const uninitReviewCmdPath = join(targetDir, ".claude", "commands", "suggestion-box", "review.md");
+  if (existsSync(uninitReviewCmdPath)) {
+    rmSync(uninitReviewCmdPath);
+    console.log("  Removed .claude/commands/suggestion-box/review.md");
+    // Clean up the suggestion-box commands dir if empty
+    try {
+      const sbCmdsDir = join(targetDir, ".claude", "commands", "suggestion-box");
+      if (readdirSync(sbCmdsDir).length === 0) {
+        rmSync(sbCmdsDir, { recursive: true });
+        // Clean up commands dir if empty too
+        const cmdsDir = join(targetDir, ".claude", "commands");
+        if (existsSync(cmdsDir) && readdirSync(cmdsDir).length === 0) {
+          rmSync(cmdsDir, { recursive: true });
+        }
+      }
+    } catch {}
+    removed++;
   }
 
   // Handle .suggestion-box directory

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -287,6 +287,96 @@ If similar feedback already exists, your submission becomes a vote on it instead
     },
   );
 
+  // -------------------------------------------------------------------------
+  // Prompt: review (slash command /review)
+  // -------------------------------------------------------------------------
+  server.prompt(
+    "review",
+    `Walk through all open feedback items one by one and triage each one (publish, dismiss, or skip).`,
+    {},
+    async () => {
+      const items = await store.listFeedback({ status: "open", sortBy: "votes" });
+
+      if (items.length === 0) {
+        return {
+          messages: [
+            {
+              role: "user" as const,
+              content: {
+                type: "text" as const,
+                text: "No open feedback items found in suggestion-box. The queue is empty — nothing to review.",
+              },
+            },
+          ],
+        };
+      }
+
+      const itemSummaries = items.map((item, i) => {
+        const impact = [
+          item.estimatedTokensSaved ? `~${item.estimatedTokensSaved} tokens saved` : null,
+          item.estimatedTimeSavedMinutes ? `~${item.estimatedTimeSavedMinutes}min saved` : null,
+        ].filter(Boolean).join(", ");
+
+        const repoHint = item.githubRepo ? ` (repo: ${item.githubRepo})` : "";
+        const titleLine = item.title ? `Title: ${item.title}\n` : "";
+        const impactLine = impact ? `Impact: ${impact}\n` : "";
+
+        return `### Item ${i + 1} of ${items.length}
+ID: ${item.id}
+Category: ${item.category} | Votes: ${item.votes} | Status: ${item.status}
+Target: ${item.targetType}/${item.targetName}${repoHint}
+${titleLine}${impactLine}Content:
+${item.content}`;
+      }).join("\n\n---\n\n");
+
+      const promptText = `You are running the suggestion-box review flow. There are **${items.length} open feedback items** to triage.
+
+Go through them one by one, in the order presented. For each item:
+
+1. **Show** the item clearly (ID, category, votes, content, target, impact if available).
+2. **Ask** the user what to do:
+   - **publish** — publish it as a GitHub issue (use \`suggestion_box_publish_to_github\`)
+     - If the item has no \`github_repo\`, ask the user to provide one (format: \`owner/repo\`)
+   - **dismiss** — mark it as dismissed (use \`suggestion_box_dismiss_feedback\`)
+   - **skip** — leave it as-is and move on
+   - **quit** — stop the review session early
+3. **Execute** the chosen action using the appropriate MCP tool.
+4. **Confirm** the result and move to the next item.
+
+After all items are processed (or the user quits), show a **summary**:
+- How many were published, dismissed, skipped
+- Links to any GitHub issues created
+
+**Important notes:**
+- Be conversational — one item at a time, wait for the user's decision before acting.
+- When publishing, if \`suggestion_box_publish_to_github\` finds an existing GitHub issue, report the deduplication result.
+- Observations are usually not worth publishing publicly — mention this when you encounter observation-category items (but let the user decide).
+- Sort preference: highest votes first (already sorted in the list below).
+
+---
+
+## Pending Feedback Queue (${items.length} items)
+
+${itemSummaries}
+
+---
+
+Start now: present **Item 1** and ask the user what to do.`;
+
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: promptText,
+            },
+          },
+        ],
+      };
+    },
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 


### PR DESCRIPTION
Adds a `/review` slash command that walks through pending feedback one item at a time and lets you triage each one conversationally.

Two ways to invoke it:
- `/mcp__suggestion-box__review` — MCP prompt registered directly on the server, loads the queue and returns instructions for the triage loop
- `/suggestion-box:review` — markdown slash command installed into `.claude/commands/` by `init`, cleaned up by `uninit`

For each item the agent shows the content, votes, and impact, then asks: publish, dismiss, skip, or quit. After finishing it shows a summary with links to any issues created. Items are sorted by votes so the high-signal stuff comes first.

Also fixes a bug where `suggestion_box_publish_to_github` was missing from `ALLOWED_TOOLS`, so `init` never added it to `permissions.allow`. The review flow depends on that tool, so without this fix every publish action would trigger a permission prompt.

Closes #104